### PR TITLE
Avoid global config setup

### DIFF
--- a/udsoncan/__init__.py
+++ b/udsoncan/__init__.py
@@ -12,12 +12,17 @@ from udsoncan.Response import Response
 import logging, logging.config
 from os import path
 log_file_path = path.join(path.dirname(path.abspath(__file__)), 'logging.conf')
-logging.config.fileConfig(log_file_path)
+#logging.config.fileConfig(log_file_path)
 
-try:
-	logging.config.fileConfig(log_file_path)
-except Exception as e:
-	logging.warning('Cannot load logging configuration. %s:%s' % (e.__class__.__name__, str(e)))
+def setup_logging():
+	"""
+	This function setup the logger accordingly to the module provided cfg file
+
+	"""
+	try:
+		logging.config.fileConfig(log_file_path)
+	except Exception as e:
+		logging.warning('Cannot load logging configuration. %s:%s' % (e.__class__.__name__, str(e)))
 
 #Define how to encode/decode a Data Identifier value to/from a binary payload
 class DidCodec:


### PR DESCRIPTION
Hi,
This pull request disable the global logging configuration present in the root module.
To be able to use this module inside a broader framework (different transport and application logic), i needed to disable the global logging configuration, otherwise the logging configuration defined in a custom application is overrided.

This is the first solution i've found, but i'm not sure is optimal for the package. You could use any other solution. 

The only result that this pull-request wants to get is to allow more use of the package (import without side-effects)

Thanks
