### PR TITLE
Fix call to client.write_data_by_identifier

### DIFF
--- a/udsoncan/client.py
+++ b/udsoncan/client.py
@@ -367,7 +367,7 @@ class Client:
 		:type didlist: int
 		
 		:param value: Value given to the :ref:`DidCodec <DidCodec>`.encode method. The payload returned by the codec will be sent to the server.
-		:type value: int
+		:type value: object
 
 		:return: The server response parsed by :meth:`WriteDataByIdentifier.interpret_response<udsoncan.services.WriteDataByIdentifier.interpret_response>`
 		:rtype: :ref:`Response<Response>`

--- a/udsoncan/services/WriteDataByIdentifier.py
+++ b/udsoncan/services/WriteDataByIdentifier.py
@@ -38,7 +38,7 @@ class WriteDataByIdentifier(BaseService):
 		didconfig = ServiceHelper.check_did_config(did, didconfig=didconfig)	# Make sure all DIDs are correctly defined in client config
 		req.data = struct.pack('>H', did)	# encode DID number
 		codec = DidCodec.from_config(didconfig[did])
-		req.data += codec.encode(value)
+		req.data += codec.encode(*value)
 
 		return req
 


### PR DESCRIPTION
Any input to `write_data_by_identifier` when using `struct` packing wouldn't work since `struct.pack` is expecting an variable number of parameters. Current implementation only passes 1 parameter.
Type conversion for DID encoder to work with tuple input. 

Also updated documentation of input type.