### PR TITLE
logging did list as hex instead of decimal

### DIFF
--- a/udsoncan/client.py
+++ b/udsoncan/client.py
@@ -364,7 +364,7 @@ class Client:
         if len(didlist) == 1:
             self.logger.info("%s - Reading data identifier : 0x%04x (%s)" % (self.service_log_prefix(services.ReadDataByIdentifier), didlist[0], DataIdentifier.name_from_id(didlist[0])))
         else:
-            self.logger.info("%s - Reading %d data identifier : %s" % (self.service_log_prefix(services.ReadDataByIdentifier), len(didlist), didlist))
+            self.logger.info("%s - Reading %d data identifier : %s" % (self.service_log_prefix(services.ReadDataByIdentifier), len(didlist), list(map(hex,didlist))))
 
         if 'data_identifiers' not in self.config or  not isinstance(self.config['data_identifiers'], dict):
             raise AttributeError('Configuration does not contains a valid data identifier description.')


### PR DESCRIPTION
To see this: - INFO - ReadDataByIdentifier<0x22> - Reading 7 data identifier : ['0xf1a0', '0x4eb9', '0x448b', '0x448c', '0xf0f3', '0xf181', '0xf180']
Instead of:  - INFO - ReadDataByIdentifier<0x22> - Reading 7 data identifier : [61856, 20153, 17547, 17548, 61683, 61825, 61824]