### PR TITLE
Request a seed with data

### DIFF
--- a/udsoncan/client.py
+++ b/udsoncan/client.py
@@ -204,7 +204,7 @@ class Client:
         return response
 
     @standard_error_management
-    def request_seed(self, level):
+    def request_seed(self, level, data=bytes()):
         """ 
         Requests a seed to unlock a security level with the :ref:`SecurityAccess<SecurityAccess>` service 
 
@@ -213,10 +213,13 @@ class Client:
         :param level: The security level to unlock. If value is even, it will be converted to the corresponding odd value
         :type level: int 
 
+        :param data: The data to send to the server
+        :type data: bytes 
+
         :return: The server response parsed by :meth:`SecurityAccess.interpret_response<udsoncan.services.SecurityAccess.interpret_response>`
         :rtype: :ref:`Response<Response>`
         """		
-        req = services.SecurityAccess.make_request(level, mode=services.SecurityAccess.Mode.RequestSeed)
+        req = services.SecurityAccess.make_request(level, mode=services.SecurityAccess.Mode.RequestSeed, data=data)
 
         self.logger.info('%s - Requesting seed to unlock security access level 0x%02x' % (self.service_log_prefix(services.SecurityAccess), req.subfunction))	# level may be corrected by service.
 
@@ -251,7 +254,7 @@ class Client:
         :return: The server response parsed by :meth:`SecurityAccess.interpret_response<udsoncan.services.SecurityAccess.interpret_response>`
         :rtype: :ref:`Response<Response>`
         """			
-        req = services.SecurityAccess.make_request(level, mode=services.SecurityAccess.Mode.SendKey, key=key)
+        req = services.SecurityAccess.make_request(level, mode=services.SecurityAccess.Mode.SendKey, data=key)
         self.logger.info('%s - Sending key to unlock security access level 0x%02x' % (self.service_log_prefix(services.SecurityAccess), req.subfunction))
         self.logger.debug('\tKey to send [%s]' % (binascii.hexlify(key)))
 

--- a/udsoncan/services/SecurityAccess.py
+++ b/udsoncan/services/SecurityAccess.py
@@ -42,7 +42,7 @@ class SecurityAccess(BaseService):
         :param mode: Type of request to perform. ``SecurityAccess.Mode.RequestSeed`` or ``SecurityAccess.Mode.SendKey`` 
         :type mode: SecurityAccess.Mode, int
 
-        :param data
+        :param data: securityAccessDataRecord (optional) for the get seed, securityKey (required) for the send key
         :type data: bytes
 
         :raises ValueError: If parameters are out of range, missing or wrong type

--- a/udsoncan/services/SecurityAccess.py
+++ b/udsoncan/services/SecurityAccess.py
@@ -30,7 +30,7 @@ class SecurityAccess(BaseService):
             return level if level % 2 == 0 else level+1
 
     @classmethod
-    def make_request(cls, level, mode, key=None):
+    def make_request(cls, level, mode, data=bytes()):
         """
         Generates a request for SecurityAccess
 
@@ -42,8 +42,8 @@ class SecurityAccess(BaseService):
         :param mode: Type of request to perform. ``SecurityAccess.Mode.RequestSeed`` or ``SecurityAccess.Mode.SendKey`` 
         :type mode: SecurityAccess.Mode, int
 
-        :param key: When mode=``SendKey``, this value must be provided.
-        :type key: bytes
+        :param data
+        :type data: bytes
 
         :raises ValueError: If parameters are out of range, missing or wrong type
         """		
@@ -53,10 +53,9 @@ class SecurityAccess(BaseService):
         ServiceHelper.validate_int(level, min=0, max=0x7F, name='Security level')
         req = Request(service=cls, subfunction=cls.normalize_level(mode=mode, level=level))
 
-        if mode == cls.Mode.SendKey:
-            if not isinstance(key, bytes):
-                raise ValueError('key must be a valid bytes object')
-            req.data = key
+        if not isinstance(data, bytes):
+            raise ValueError('key must be a valid bytes object')
+        req.data = data
 
         return req
 


### PR DESCRIPTION
In accordance with the ISO 14229:2006, it's possible to request a seed with data:

`securityAccessDataRecord: This parameter record is user optionally to transmit data to a server when requesting the seed information. It can e.g. contain identification of the client that is verified in the server.`

Maybe the unit tests need to be updated for this change. I didn't find how to run them.