### PR TITLE
Add option for the client send_request() to respect the overall_timeout

### DIFF
--- a/doc/source/udsoncan/client.rst
+++ b/doc/source/udsoncan/client.rst
@@ -202,9 +202,14 @@ See :ref:`an example <example_security_algo>`
 .. attribute:: request_timeout
    :annotation: (float)
 
-   Maximum amount of time in seconds to wait for a response (positive or negative except NRC 0x78) after sending a request.
-   After this time is elapsed, a TimeoutException will be raised regardless of other timeouts value or previous client response.
-   Ensure an exit path if the ECU keeps requesting to wait.
+   Maximum amount of time in seconds to wait for a response of any kind, positive or negative, after sending a request.
+   After this time is elapsed, a TimeoutException will be raised regardless of other timeouts value or previous client responses.
+   In particular even if the server requests that the client wait, by returning response requestCorrectlyReceived-ResponsePending (0x78),
+   this timeout will still trigger.
+
+   If you wish to disable this behaviour and have your server wait for as long as it takes for the ECU to finish whatever activity
+   you have requested, set this value to None.
+
    Default value of 5
 
 .. _config_p2_timeout:

--- a/test/client/test_client.py
+++ b/test/client/test_client.py
@@ -58,7 +58,8 @@ class TestClient(ClientServerTest):
             self.assertGreater(diff, timeout, 'Timeout raised after %.3f seconds when it should be %.3f sec' % (diff, timeout))
             self.assertLess(diff, timeout+0.5, 'Timeout raised after %.3f seconds when it should be %.3f sec' % (diff, timeout))
 
-    #  overall timeout is set to 0.5. Server respond "pendingResponse" for 1 sec. Client should timeout first.
+    # Overall timeout is set to 0.5. Server respond "pendingResponse" for 1 sec. 
+    # Client should timeout first as we are setting respect_overall_timeout True.
     def test_overall_timeout_pending_response(self):
         if not hasattr(self, 'completed'):
             self.completed = False
@@ -75,7 +76,7 @@ class TestClient(ClientServerTest):
         self.udsclient.set_configs({'request_timeout': timeout, 'p2_timeout' : 2, 'p2_star_timeout':2})
         try:
             t1 = time.time()
-            response = self.udsclient.send_request(req)
+            response = self.udsclient.send_request(req, respect_overall_timeout=True)
             raise Exception('Request did not raise a TimeoutException')
         except TimeoutException as e:
             self.assertIsNotNone(self.udsclient.last_response, 'Client never received the PendingResponse message')
@@ -106,6 +107,62 @@ class TestClient(ClientServerTest):
             diff = time.time() - t1
             self.assertGreater(diff, timeout, 'Timeout raised after %.3f seconds when it should be %.3f sec' % (diff, timeout))
             self.assertLess(diff, timeout+0.5, 'Timeout raised after %.3f seconds when it should be %.3f sec' % (diff, timeout))
+
+    # send RequestCorrectlyReceived_ResponsePending responses until well beyond overall_timeout to check response
+    # This function is used in 2 tests:
+    #  * checking there is a timeout when the overall_timeout is repected
+    #  * checking that the full transaction is allowed to complete with the overall_timeout is ignored 
+    def RCRRP_responses(self):
+        overall_timeout = 2.0
+        self.conn.touserqueue.get(timeout=0.2)
+        response = Response(service=services.TesterPresent, code=Response.Code.RequestCorrectlyReceived_ResponsePending)
+        t1 = time.time()
+        while time.time() - t1 <= 2*overall_timeout:
+            self.conn.fromuserqueue.put(response.get_payload())
+            time.sleep(0.1)
+        response = Response(service=services.TesterPresent, code=Response.Code.PositiveResponse, data=bytes(2))
+        self.conn.fromuserqueue.put(response.get_payload())
+    
+    def RCRRP_responses_check(self, respect_overall_timeout):
+        req = Request(service = services.TesterPresent, subfunction=0) 
+        overall_timeout = 2.0
+        p2_star_timeout = 1.0
+
+        self.udsclient.set_configs({'request_timeout': overall_timeout, 'p2_timeout' : 0.5, 'p2_star_timeout':p2_star_timeout})
+        if respect_overall_timeout:
+            timeout = overall_timeout
+        else:
+            # Server is going to send RCRRP for 2*overall timeout.  Then the client will wait for P2*
+            timeout = 2*overall_timeout + p2_star_timeout
+
+        t1 = time.time()
+        try:
+            response = self.udsclient.send_request(req)
+        except TimeoutException as e:
+            if respect_overall_timeout:
+                diff = time.time() - t1
+                self.assertGreater(diff, timeout, 'Timeout raised after %.3f seconds when it should be %.3f sec' % (diff, timeout))
+                self.assertLess(diff, timeout+0.5, 'Timeout raised after %.3f seconds when it should be %.3f sec' % (diff, timeout))
+                self.assertIsNotNone(self.udsclient.last_response, 'Client never received the PendingResponse message')
+            else:
+                raise Exception('Request raised a TimeoutException')
+        if not respect_overall_timeout:
+            self.assertEqual(self.udsclient.last_response.code, Response.Code.PositiveResponse, 'Client never received the Positive Response')
+        self.completed = True
+
+    #  Sends "pending response" responses to go past the overall_timeout and check there is a timeout when overall_timeout is respected.
+    def test_RCRRP_with_overall_timeout(self):
+        self.RCRRP_responses()
+
+    def _test_RCRRP_with_overall_timeout(self):
+        self.RCRRP_responses_check(respect_overall_timeout=True)
+
+    # Sends "pending response" responses to got past the overall_timeout and check there is no timeout in default state.
+    def test_RCRRP_no_overall_timeout(self):
+        self.RCRRP_responses()
+
+    def _test_RCRRP_no_overall_timeout(self):
+        self.RCRRP_responses_check(respect_overall_timeout=False)
 
     #  Sends 2 "pending response" response to switch to P2* timeout.
     def test_p2_star_timeout_overrided_by_diagnostic_session_control(self):

--- a/test/client/test_client.py
+++ b/test/client/test_client.py
@@ -148,7 +148,6 @@ class TestClient(ClientServerTest):
                 raise Exception('Request raised a TimeoutException')
         if not respect_overall_timeout:
             self.assertEqual(self.udsclient.last_response.code, Response.Code.PositiveResponse, 'Client never received the Positive Response')
-        self.completed = True
 
     #  Sends "pending response" responses to go past the overall_timeout and check there is a timeout when overall_timeout is respected.
     def test_RCRRP_with_overall_timeout(self):

--- a/udsoncan/client.py
+++ b/udsoncan/client.py
@@ -1601,7 +1601,7 @@ class Client:
         return response
 
     # Basic transmission of requests. This will need to be improved
-    def send_request(self, request, timeout=-1):
+    def send_request(self, request, timeout=-1, respect_overall_timeout=False):
         if timeout < 0:
             # Timeout not provided by user: defaults to Client request_timeout value
             overall_timeout = self.config['request_timeout']
@@ -1640,7 +1640,7 @@ class Client:
             self.logger.debug("Waiting for server response")
 
             try:
-                if time.time() + single_request_timeout < overall_timeout_time:	
+                if not respect_overall_timeout or time.time() + single_request_timeout < overall_timeout_time:	
                     timeout_type_used 	= 'single_request'
                     timeout_value 		= single_request_timeout
                 else:	

--- a/udsoncan/client.py
+++ b/udsoncan/client.py
@@ -1601,16 +1601,21 @@ class Client:
         return response
 
     # Basic transmission of requests. This will need to be improved
-    def send_request(self, request, timeout=-1, respect_overall_timeout=False):
+    def send_request(self, request, timeout=-1):
         if timeout < 0:
             # Timeout not provided by user: defaults to Client request_timeout value
             overall_timeout = self.config['request_timeout']
             p2 = self.config['p2_timeout'] if self.session_timing['p2_server_max'] is None else self.session_timing['p2_server_max']
-            single_request_timeout = min(overall_timeout, p2)
+            if overall_timeout is not None:
+                single_request_timeout = min(overall_timeout, p2)
+            else:
+                single_request_timeout = p2
         else:
             overall_timeout = timeout
             single_request_timeout = timeout
-
+        respect_overall_timeout = True
+        if overall_timeout is None:
+            respect_overall_timeout = False
         using_p2_star = False	# Will switch to true when Nrc 0x78 will be received the first time.
 
         self.conn.empty_rxqueue()
@@ -1634,13 +1639,14 @@ class Client:
             return
 
         done_receiving = False
-        overall_timeout_time = time.time() + overall_timeout
+        if respect_overall_timeout:
+            overall_timeout_time = time.time() + overall_timeout
         while not done_receiving:
             done_receiving = True
             self.logger.debug("Waiting for server response")
 
             try:
-                if not respect_overall_timeout or time.time() + single_request_timeout < overall_timeout_time:	
+                if not respect_overall_timeout or (respect_overall_timeout and time.time() + single_request_timeout < overall_timeout_time):
                     timeout_type_used 	= 'single_request'
                     timeout_value 		= single_request_timeout
                 else:	


### PR DESCRIPTION
I have added an option to send_request() to switch between the original behaviour (which uses the overall_timeout to stop a transaction if the server continues to send RequestCorrectlyReceived_ResponsePending) and new behaviour (which causes the client to behave in the fully spec-compliant fashion and wait for as long as the server requests it to).  

The default behaviour is the new behaviour, as it seems to me that the original behaviour is for special cases where the server is buggy or untrusted. See the discussion on issue #73.

Two new tests are added to check both sides of this behaviour.