### PR TITLE
Fixed issues found trying out a few examples

### DIFF
--- a/doc/source/udsoncan/examples.rst
+++ b/doc/source/udsoncan/examples.rst
@@ -191,7 +191,7 @@ This example shows how to configure the client with a DID configuration and requ
       print(response.service_data.values[0xF190]) # This is a dict of DID:Value
       
       # Or, if a single DID is expected, a shortcut to read the value of the first DID
-      vin = client.read_data_by_identifier_first(0xF190)     
+      vin = client.read_data_by_identifier_first([0xF190])     
       print(vin)  # 'ABCDE0123456789' (15 chars)
 
 -----

--- a/doc/source/udsoncan/examples.rst
+++ b/doc/source/udsoncan/examples.rst
@@ -82,13 +82,13 @@ Note that, in order to run this code, both ``python-can`` and ``can-isotp`` must
       'stmin' : 32,                          # Will request the sender to wait 32ms between consecutive frame. 0-127ms or 100-900ns with values from 0xF1-0xF9
       'blocksize' : 8,                       # Request the sender to send 8 consecutives frames before sending a new flow control message
       'wftmax' : 0,                          # Number of wait frame allowed before triggering an error
-      'tx_data_length ' : 8,                 # Link layer (CAN layer) works with 8 byte payload (CAN 2.0)
-      'tx_data_min_length  ' : None,         # Minimum length of CAN messages. When different from None, messages are padded to meet this length. Works with CAN 2.0 and CAN FD.
+      'tx_data_length' : 8,                  # Link layer (CAN layer) works with 8 byte payload (CAN 2.0)
+      'tx_data_min_length' : None,           # Minimum length of CAN messages. When different from None, messages are padded to meet this length. Works with CAN 2.0 and CAN FD.
       'tx_padding' : 0,                      # Will pad all transmitted CAN messages with byte 0x00. 
       'rx_flowcontrol_timeout' : 1000,       # Triggers a timeout if a flow control is awaited for more than 1000 milliseconds
       'rx_consecutive_frame_timeout' : 1000, # Triggers a timeout if a consecutive frame is awaited for more than 1000 milliseconds
       'squash_stmin_requirement' : False,    # When sending, respect the stmin requirement of the receiver. If set to True, go as fast as possible.
-      'max_frame_size ' : 4095               # Limit the size of receive frame.
+      'max_frame_size' : 4095                # Limit the size of receive frame.
    }
 
    bus = VectorBus(channel=0, bitrate=500000)                                          # Link Layer (CAN protocol)
@@ -162,6 +162,7 @@ This example shows how to configure the client with a DID configuration and requ
    from udsoncan.connections import IsoTPSocketConnection
    from udsoncan.client import Client
    import udsoncan.configs
+   import struct
 
    class MyCustomCodecThatShiftBy4(udsoncan.DidCodec):
       def encode(self, val):
@@ -173,7 +174,7 @@ This example shows how to configure the client with a DID configuration and requ
          return val >> 4                        # Do some stuff (reversed)
 
       def __len__(self):
-         return 4    # encoded paylaod is 4 byte long.
+         return 4    # encoded payload is 4 byte long.
 
 
    config = dict(udsoncan.configs.default_client_config)
@@ -186,7 +187,7 @@ This example shows how to configure the client with a DID configuration and requ
    # IsoTPSocketconnection only works with SocketCAN under Linux. Use another connection if needed.
    conn = IsoTPSocketConnection('vcan0', rxid=0x123, txid=0x456)  
    with Client(conn,  request_timeout=2, config=config) as client:
-      response = client.read_data_by_identifier(0xF190)
+      response = client.read_data_by_identifier([0xF190])
       print(response.service_data.values[0xF190]) # This is a dict of DID:Value
       
       # Or, if a single DID is expected, a shortcut to read the value of the first DID


### PR DESCRIPTION
Found some minor issues as I tried to get a few of the UDS examples working on my hardware.

1. Extra spaces in `isotp_params` keys caused run-time errors
2. Missing `import struct` in what appears to be a complete example
3. Inconsistent use since the docs say these are lists so I changed it (but I see that `validate_didlist_input` takes care of this).  
```
      response = client.read_data_by_identifier([0xF190])
      print(response.service_data.values[0xF190]) # This is a dict of DID:Value
      
      # Or, if a single DID is expected, a shortcut to read the value of the first DID
      vin = client.read_data_by_identifier_first([0xF190])     
```
Hope you find these useful. 

Rick