### PR TITLE
WIP: Allow to receive multiple responses to one request

### DIFF
--- a/test/client/test_iter_responses.py
+++ b/test/client/test_iter_responses.py
@@ -1,0 +1,45 @@
+
+from queue import Empty
+
+from test.ClientServerTest import ClientServerTest
+
+class TestTterResponses(ClientServerTest):
+    def __init__(self, *args, **kwargs):
+        ClientServerTest.__init__(self, *args, **kwargs)
+
+    def test_iter_responses_success(self):
+        request = self.conn.touserqueue.get(timeout=0.2)
+        self.assertEqual(request, b"\x3E\x00")
+        self.conn.fromuserqueue.put(b"\x7E\x00") # Positive response
+        self.conn.fromuserqueue.put(b"\x7E\x00") # Positive response
+        self.conn.fromuserqueue.put(b"\x7F\x3E\x78") # Response Pending
+        self.conn.fromuserqueue.put(b"\x7F\x3E\x78") # Response Pending
+        self.conn.fromuserqueue.put(b"\x7E\x00") # Positive response
+
+        # Check that we received the request only once
+        with self.assertRaises(Empty):
+            self.conn.touserqueue.get(timeout=1)
+
+    def _test_iter_responses_success(self):
+        response = self.udsclient.tester_present()
+        responses = self.udsclient.iter_responses(response)
+        self.assertEqual(len(responses), 3)
+        for res in responses:
+            self.assertIsNotNone(res)
+
+    def test_iter_responses_error(self):
+        request = self.conn.touserqueue.get(timeout=0.2)
+        self.assertEqual(request, b"\x3E\x00")
+        self.conn.fromuserqueue.put(b"\x7F\x3E\x10") # General Reject
+        self.conn.fromuserqueue.put(b"\x7E\x00") # Positive response
+        self.conn.fromuserqueue.put(b"\x7E\x00") # Positive response
+        with self.assertRaises(Empty):
+            # Check that we received the request only once
+            self.conn.touserqueue.get(timeout=1)
+
+    def _test_iter_responses_error(self):
+        self.udsclient.set_config('exception_on_negative_response', False)
+        responses = self.udsclient.iter_responses(self.udsclient.tester_present())
+        self.assertEqual(len(responses), 3)
+        for res in responses:
+            self.assertIsNotNone(res)

--- a/test/client/test_iter_responses.py
+++ b/test/client/test_iter_responses.py
@@ -26,6 +26,7 @@ class TestTterResponses(ClientServerTest):
         self.assertEqual(len(responses), 3)
         for res in responses:
             self.assertIsNotNone(res)
+            self.assertIsNotNone(res.service_data)
 
     def test_iter_responses_error(self):
         request = self.conn.touserqueue.get(timeout=0.2)
@@ -43,3 +44,7 @@ class TestTterResponses(ClientServerTest):
         self.assertEqual(len(responses), 3)
         for res in responses:
             self.assertIsNotNone(res)
+
+        self.assertFalse(responses[0].positive)
+        self.assertIsNotNone(responses[1].service_data)
+        self.assertIsNotNone(responses[2].service_data)

--- a/udsoncan/client.py
+++ b/udsoncan/client.py
@@ -1715,11 +1715,13 @@ class Client:
         if response is None:
             return []
         
+        service = response.service
         responses = []
         while response is not None:
             responses.append(response)
             try:
-                response = self._receive_reponse(response.service)
+                response = self._receive_reponse(service)
+                service.interpret_response(response)
             except TimeoutException:
                 response = None
         return responses


### PR DESCRIPTION
Helps with https://github.com/pylessard/python-udsoncan/issues/88#issuecomment-1008140928

## What's done
* Allow converting one response to a response list.
* Populate each response `service_data`.
* Handling of NRC Pending Response
* Allow user to receive all responses even if some of them are erroneous (requires changing the configuration accordingly)

## What's not done? (Outside the scope of this PR)
* Currently the client does not validate the consecutive responses, since the logic exists only in the client method.
That logic most likely needs be moved from the client to a `Service.validate_response(request, response)` method.
* Timeout handling treats each response independently of the others.
* Who sent the individual response (in case of functional addressing) is not available due to Connection API limitation.