### PR TITLE
Add custom services by extending BaseService

### DIFF
--- a/udsoncan/services/ReadDataByIdentifier.py
+++ b/udsoncan/services/ReadDataByIdentifier.py
@@ -50,7 +50,7 @@ class ReadDataByIdentifier(BaseService):
         didlist = cls.validate_didlist_input(didlist)
 
         req = Request(cls)
-        ServiceHelper.check_did_config(didlist, didconfig)
+        didconfig = ServiceHelper.check_did_config(didlist, didconfig)
 
         did_reading_all_data = None
         for did in didlist:


### PR DESCRIPTION
This PR performs two total actions:
Fixes a bug in udsoncan services relating to passing a configuration that has data_identifiers as part of its dictionary not functioning. And allows for response_ids and request_ids to be taken from the subclasses of BaseService, this allows for services to be created outside of udsoncan that don't quite fit the UDS specification but still behave similarly to other portions of the UDS protocol and prevents a need to dive into IsoTP sockets when otherwise unnecessary.