### PR TITLE
Fix Unbound Local Error

### DIFF
--- a/udsoncan/client.py
+++ b/udsoncan/client.py
@@ -2166,6 +2166,8 @@ class Client:
                     timeout_value = max(overall_timeout_time - time.time(), 0)
 
                 recv_payload = self.conn.wait_frame(timeout=timeout_value, exception=True)
+                if recv_payload is None:
+                    timeout_name_to_report = 'No payload received'
             except TimeoutException:
                 if timeout_type_used == 'single_request':
                     timeout_name_to_report = 'P2* timeout' if using_p2_star else 'P2 timeout'


### PR DESCRIPTION
In the method `send_request` when receive payload is None the variable `timeout_name_to_report` is not set and causes the error.  

[UnboundLocalError] : cannot access local variable 'timeout_name_to_report' where it is not associated with a value  
-> ...\udsoncan\client.py:2185  