### PR TITLE
Fix J2534: ERR_CONCURRENT_API_CALL with using Pulsar

### DIFF
--- a/udsoncan/connections.py
+++ b/udsoncan/connections.py
@@ -846,7 +846,8 @@ class J2534Connection(BaseConnection):
     def specific_send(self, payload: bytes, timeout: Optional[float] = None):
         if timeout is None:
             timeout = 0
-        result = self.interface.PassThruWriteMsgs(self.channelID, payload, self.protocol.value, Timeout=int(timeout * 1000))
+        self.result = self.interface.PassThruWriteMsgs(self.channelID, payload, self.protocol.value, Timeout=int(timeout * 1000))
+        self.log_last_operation('PassThruWriteMsgs', with_raise=True)
 
     def specific_wait_frame(self, timeout: Optional[float] = None) -> Optional[bytes]:
         if not self.opened:

--- a/udsoncan/connections.py
+++ b/udsoncan/connections.py
@@ -813,6 +813,7 @@ class J2534Connection(BaseConnection):
     def rxthread_task(self) -> None:
         while not self.exit_requested:
             try:
+                time.sleep(0.02) # FIXME avoid ERR_CONCURRENT_API_CALL
                 result, data, numMessages = self.interface.PassThruReadMsgs(self.channelID, self.protocol.value, 1, 1)
                 if data is not None:
                     self.rxqueue.put(data)

--- a/udsoncan/connections.py
+++ b/udsoncan/connections.py
@@ -795,6 +795,7 @@ class J2534Connection(BaseConnection):
 
     def open(self) -> "J2534Connection":
         self.exit_requested = False
+        self.sem = threading.Semaphore()
         self.rxthread = threading.Thread(target=self.rxthread_task, daemon=True)
         self.rxthread.start()
         self.opened = True
@@ -812,14 +813,16 @@ class J2534Connection(BaseConnection):
 
     def rxthread_task(self) -> None:
         while not self.exit_requested:
+            self.sem.acquire()
             try:
-                time.sleep(0.02) # FIXME avoid ERR_CONCURRENT_API_CALL
                 result, data, numMessages = self.interface.PassThruReadMsgs(self.channelID, self.protocol.value, 1, 1)
                 if data is not None:
                     self.rxqueue.put(data)
             except Exception:
                 self.logger.critical("Exiting J2534 rx thread")
                 self.exit_requested = True
+            self.sem.release()
+            time.sleep(0.001)
 
     def log_last_operation(self, exec_method: str, with_raise = False) -> None:
         if self.result != Error_ID.ERR_SUCCESS:
@@ -845,10 +848,13 @@ class J2534Connection(BaseConnection):
         self.log_last_operation('PassThruClose')
 
     def specific_send(self, payload: bytes, timeout: Optional[float] = None):
-        if timeout is None:
-            timeout = 0
+        timeout = 0 if timeout is None else timeout
+
+        # Fix for avoid ERR_CONCURRENT_API_CALL. Stop reading
+        self.sem.acquire()
         self.result = self.interface.PassThruWriteMsgs(self.channelID, payload, self.protocol.value, Timeout=int(timeout * 1000))
         self.log_last_operation('PassThruWriteMsgs', with_raise=True)
+        self.sem.release()
 
     def specific_wait_frame(self, timeout: Optional[float] = None) -> Optional[bytes]:
         if not self.opened:

--- a/udsoncan/j2534.py
+++ b/udsoncan/j2534.py
@@ -185,7 +185,7 @@ class J2534():
         if not pDeviceID:
             pDeviceID = ctypes.c_ulong()
 
-        result = dllPassThruOpen(ctypes.POINTER(ctypes.c_int)(), byref(pDeviceID))
+        result = dllPassThruOpen(bytes('J2534-2:', 'ascii'), byref(pDeviceID))
         return Error_ID(hex(result)), pDeviceID
 
     def PassThruConnect(self, deviceID, protocol, baudrate, pChannelID=None):


### PR DESCRIPTION
![ERR_CONCURRENT_API_CALL](https://github.com/user-attachments/assets/1637dded-19e4-4f46-92d0-8adcd45d387b)

Im added **log_last_operation** after **PassThruWriteMsgs** and this fix show me which real reason didnt work Pulsar correctly.

I temporarily fix this problem by adding before reading - time.sleep(0.02). Doesn't seem to be a good idea.